### PR TITLE
credit 계산을 위한 pblk 정보 가져오는 방법 개선

### DIFF
--- a/drivers/lightnvm/pblk-init.c
+++ b/drivers/lightnvm/pblk-init.c
@@ -85,6 +85,14 @@ static blk_qc_t pblk_make_rq(struct request_queue *q, struct bio *bio)
 		blkcg->gc_active = pblk_free_line_check(pblk);
 	}
 	*/
+
+	if (blkcg->weight) {
+		if (!blkcg->passed) {
+			blkcg->passed = true;
+		}
+		blkcg->private = (void *)pblk;
+	}
+
 	/* Read requests must be <= 256kb due to NVMe's 64 bit completion bitmap
 	 * constraint. Writes can be of arbitrary size.
 	 */

--- a/include/linux/blk-cgroup.h
+++ b/include/linux/blk-cgroup.h
@@ -61,6 +61,7 @@ struct blkcg {
 #endif
 	unsigned int weight;
 	int gc_active;
+	void *private;
 	bool passed;
 };
 


### PR DESCRIPTION
# `end_io` 기반한 제작 관련 내용

`end_io`가 부르는 상황에서 값을 반환하게 개발하면 속도가 더 빠를 것으로 예상된다고 이야기했습니다. 하지만 동작 과정을 ftrace를 통해 분석해 본 결과, 이러한 방식이 성능 저하를 일으킬 수 있음을 확인하였습니다.

먼저 credit에 대한 판단은 `tj_with_in_credit_limit`에서 계산하는 것을 앞선 이메일에서 확인했습니다. 따라서 이 함수를 부르는 유일한 함수인 `blk_throttle_io`함수를 `end_io` 발생 시에 부를 수 있도록 하려고 했습니다.

![blk_throttle_io 호출 시점](https://user-images.githubusercontent.com/16631264/80313307-15da0a80-8825-11ea-9065-86ae4d2793a9.PNG)

그래서 기존 소스 코드에 대한 함수 수행 과정을 먼저 분석했습니다. 확인해 본 결과, 위 그림과 같이 `blk_throtl_bio`가 약 1.5us 내외의 시간을 소비하였고, 대체로 `end_io` 이후와 `make_rq` 전에 불리는 것을 확인할 수 있었습니다. 이는 굳이 `blk_throtl_bio`를 저희가 강제로 호출하지 않아도 대체로 호출되었으면 하는 위치에서 호출되는 것을 알 수 있었습니다.

다시 말해, 충분히 `blk_throtl_bio`는 최적화되어서 불리고 있는 것이라고 예상할 수 있었습니다. 그리고 역시나 아니나 다를까 제가 `end_io`를 강제로 붙여서 동작을 하게 해봤지만 I/O가 수행될 시 앞뒤로 추가적인 1.5us의 부하만 만들고, 시스템의 안정성을 저하시키는 것 외에는 크게 메리트가 있는 수행 방식은 아니었습니다.

# 개선 내용

앞서 언급한 `end_io`는 파기하였습니다. 대신에 gc를 카운트만 하는 기존의 코드에서 좀 더 나아가서 pblk의 모든 정보를 가져올 수 있도록 개선하였습니다.

작성하신 코드에 기반하여 만들었고, 수행해 본 결과 별 무리 없이 값을 잘 가져오는 것을 확인하였습니다.

만약 이 PR을 도입하시겠다면 아래 내용들이 추가적으로 더 논의 되어야 할 것 같습니다.

1. pblk에서 `make_rq`가 일어날 때에 `cgroup`의 정보를 알아낼 수 있는가?
2. GC는 디스크가 가득차기 전까지 굉장히 희박하게 발생하는 데, 차라리 cgroup별 R/W량에 기반하는 것이 어떤가?